### PR TITLE
Add AI Social Wellness Companion

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -250,6 +250,26 @@ html, body {
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), inset 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+/* Rose — Wellness */
+.lego-rose {
+	background: linear-gradient(180deg, #f472b6 0%, #ec4899 100%);
+	color: white;
+	text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+	border-bottom: 4px solid #9d174d;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.lego-rose:hover:not(:disabled) {
+	background: linear-gradient(180deg, #f9a8d4 0%, #f472b6 100%);
+	box-shadow: 0 4px 12px rgba(236, 72, 153, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.lego-rose:active:not(:disabled) {
+	border-bottom-width: 1px;
+	background: linear-gradient(180deg, #ec4899 0%, #db2777 100%);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), inset 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
 /* ─── Active toggle state (for beacon responses) ─── */
 .lego-emerald.active {
 	background: linear-gradient(180deg, #34d399 0%, #059669 100%);

--- a/src/convex/_generated/api.d.ts
+++ b/src/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as signaling from "../signaling.js";
 import type * as stickers from "../stickers.js";
 import type * as users from "../users.js";
 import type * as validators from "../validators.js";
+import type * as wellness from "../wellness.js";
 
 import type {
   ApiFromModules,
@@ -54,6 +55,7 @@ declare const fullApi: ApiFromModules<{
   stickers: typeof stickers;
   users: typeof users;
   validators: typeof validators;
+  wellness: typeof wellness;
 }>;
 
 /**

--- a/src/convex/wellness.ts
+++ b/src/convex/wellness.ts
@@ -1,0 +1,625 @@
+import { v } from "convex/values";
+import { action, internalQuery, mutation } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+/**
+ * AI Social Wellness Companion — powered by Claude Opus 4.6
+ *
+ * Gathers social graph data (friendships, beacons, responses, notes)
+ * and asks Claude to generate a personalized wellness report.
+ */
+
+// ── Types ──
+
+interface FriendInsight {
+	name: string;
+	emoji: string;
+	status: "thriving" | "connected" | "drifting" | "new";
+	insight: string;
+	suggestion: string;
+}
+
+interface ActivitySuggestion {
+	emoji: string;
+	title: string;
+	description: string;
+	bestFor: string;
+	timing: string;
+}
+
+interface CharityCause {
+	emoji: string;
+	cause: string;
+	whyItFits: string;
+	firstStep: string;
+}
+
+export interface WellnessReport {
+	overallHealth: "thriving" | "connected" | "growing" | "needs-attention";
+	healthScore: number;
+	summary: string;
+	friendInsights: FriendInsight[];
+	activitySuggestions: ActivitySuggestion[];
+	charityCause: CharityCause;
+	weeklyNudge: string;
+}
+
+// ── Internal query: gather all social data for one user ──
+
+export const gatherSocialData = internalQuery({
+	args: { userUuid: v.string() },
+	handler: async (ctx, args) => {
+		const { userUuid } = args;
+
+		// 1. Get user record
+		const user = await ctx.db
+			.query("users")
+			.withIndex("by_uuid", (q) => q.eq("uuid", userUuid))
+			.first();
+		if (!user) throw new Error("User not found");
+
+		// 2. Get accepted friendships (both directions, compound indexes)
+		const [asRequester, asReceiver] = await Promise.all([
+			ctx.db
+				.query("friendships")
+				.withIndex("by_requester_status", (q) =>
+					q.eq("requesterId", userUuid).eq("status", "accepted")
+				)
+				.collect(),
+			ctx.db
+				.query("friendships")
+				.withIndex("by_receiver_status", (q) =>
+					q.eq("receiverId", userUuid).eq("status", "accepted")
+				)
+				.collect(),
+		]);
+
+		const friendUuids = [
+			...asRequester.map((f) => f.receiverId),
+			...asReceiver.map((f) => f.requesterId),
+		];
+
+		// 3. Resolve friend user records (parallel)
+		const friends = await Promise.all(
+			friendUuids.map((uuid) =>
+				ctx.db
+					.query("users")
+					.withIndex("by_uuid", (q) => q.eq("uuid", uuid))
+					.first()
+			)
+		);
+		const friendData = friends.filter(Boolean).map((f) => ({
+			uuid: f!.uuid,
+			username: f!.username,
+			displayName: f!.displayName,
+		}));
+
+		// 4. Get recent beacons created by user + friends (last 30 days)
+		const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+		const allUuids = [userUuid, ...friendUuids];
+
+		const recentBeacons = await Promise.all(
+			allUuids.map(async (uuid) => {
+				const objects = await ctx.db
+					.query("canvasObjects")
+					.withIndex("by_creator_type", (q) =>
+						q.eq("creatorId", uuid).eq("type", "beacon")
+					)
+					.collect();
+				return objects
+					.filter((o) => o._creationTime > thirtyDaysAgo)
+					.map((o) => ({
+						id: o._id,
+						creatorId: o.creatorId,
+						title: (o.content as any).title as string,
+						description: (o.content as any).description as string | undefined,
+						startTime: (o.content as any).startTime as number,
+						endTime: (o.content as any).endTime as number,
+						createdAt: o._creationTime,
+					}));
+			})
+		);
+		const allBeacons = recentBeacons.flat();
+
+		// 5. Get beacon responses for those beacons (parallel)
+		const beaconResponses = await Promise.all(
+			allBeacons.map(async (beacon) => {
+				const responses = await ctx.db
+					.query("beaconResponses")
+					.withIndex("by_beacon", (q) => q.eq("beaconId", beacon.id as any))
+					.collect();
+				return {
+					beaconId: beacon.id,
+					beaconTitle: beacon.title,
+					responses: responses.map((r) => ({
+						userId: r.userId,
+						status: r.status,
+					})),
+				};
+			})
+		);
+
+		// 6. Get recent notes on user's personal canvas (interest signals)
+		const personalCanvas = await ctx.db
+			.query("canvases")
+			.withIndex("by_owner_type", (q) =>
+				q.eq("ownerId", userUuid).eq("type", "personal")
+			)
+			.first();
+
+		let recentNotes: { text: string; title?: string }[] = [];
+		if (personalCanvas) {
+			const objects = await ctx.db
+				.query("canvasObjects")
+				.withIndex("by_canvas", (q) => q.eq("canvasId", personalCanvas._id))
+				.collect();
+			recentNotes = objects
+				.filter((o) => o.type === "textblock" && o._creationTime > thirtyDaysAgo)
+				.slice(0, 10)
+				.map((o) => ({
+					text: ((o.content as any).text as string)?.slice(0, 200) ?? "",
+					title: (o.content as any).title as string | undefined,
+				}));
+		}
+
+		// 7. Friendship creation dates (how long they've been friends)
+		const friendshipDates = [...asRequester, ...asReceiver].map((f) => ({
+			friendUuid: f.requesterId === userUuid ? f.receiverId : f.requesterId,
+			since: f.createdAt,
+		}));
+
+		return {
+			user: {
+				username: user.username,
+				displayName: user.displayName,
+			},
+			friends: friendData,
+			friendshipDates,
+			beacons: allBeacons,
+			beaconResponses,
+			recentNotes,
+			now: Date.now(),
+		};
+	},
+});
+
+// ── Action: generate wellness report via Claude Opus 4.6 ──
+
+export const generateReport = action({
+	args: {},
+	handler: async (ctx): Promise<WellnessReport> => {
+		// Verify caller is authenticated
+		const userUuid = await ctx.runQuery(internal.users.verifyAuth);
+
+		// Gather all social data
+		const data = await ctx.runQuery(internal.wellness.gatherSocialData, {
+			userUuid,
+		});
+
+		const apiKey = process.env.ANTHROPIC_API_KEY;
+		if (!apiKey) {
+			throw new Error("AI wellness not configured");
+		}
+
+		const systemPrompt = `You are the Social Wellness Companion for Orbyt, a non-addictive social connection platform. Your job is to analyze a user's social graph and help them nurture their real-world friendships — not keep them on screen.
+
+You'll receive structured data about:
+- The user's friends
+- How long they've been friends
+- Recent beacons (spontaneous/planned hangout invitations)
+- Beacon responses (who's joining, interested, or declining)
+- Recent notes on their canvas (interest/topic signals)
+
+Analyze this data and return a JSON wellness report. Be warm, specific, and actionable. Reference actual friend names and real patterns you see. Never be judgmental — frame everything positively. If someone is drifting, suggest a gentle reconnection, not a guilt trip.
+
+Your response must be ONLY valid JSON matching this exact schema:
+{
+  "overallHealth": "thriving" | "connected" | "growing" | "needs-attention",
+  "healthScore": 1-100,
+  "summary": "2-3 warm sentences about their overall social health",
+  "friendInsights": [
+    {
+      "name": "friend's display name",
+      "emoji": "single emoji that captures the vibe",
+      "status": "thriving" | "connected" | "drifting" | "new",
+      "insight": "1 sentence about this friendship's current state",
+      "suggestion": "1 specific, actionable idea for this friendship"
+    }
+  ],
+  "activitySuggestions": [
+    {
+      "emoji": "activity emoji",
+      "title": "Short activity name (2-5 words)",
+      "description": "1-2 sentences selling the vibe",
+      "bestFor": "which friends this is best for",
+      "timing": "when to do it (natural language)"
+    }
+  ],
+  "charityCause": {
+    "emoji": "cause emoji",
+    "cause": "Specific cause or organization name",
+    "whyItFits": "1 sentence connecting this cause to the friend group's interests/activities",
+    "firstStep": "1 specific, easy first action they can take together"
+  },
+  "weeklyNudge": "One gentle, specific action for this week — reference a real friend or pattern"
+}
+
+Rules:
+- activitySuggestions: exactly 3 ideas, varied in intensity/setting
+- friendInsights: one per friend (max 10)
+- Activities should be real-world, in-person, fun — not screen-based
+- charityCause should connect to the group's actual interests (sports = youth athletics, food = food banks, outdoors = conservation, etc.)
+- weeklyNudge should be ONE specific thing they can do THIS WEEK
+- If there are few friends or beacons, be encouraging about building connections, not critical
+- Keep the tone like a wise friend, not a therapist or corporate wellness app
+- No markdown, no code fences — pure JSON only`;
+
+		const friendLines = data.friends.length > 0
+			? data.friends.map((f) => {
+				const friendship = data.friendshipDates.find(
+					(fd) => fd.friendUuid === f.uuid
+				);
+				const daysSince = friendship
+					? Math.floor((data.now - friendship.since) / (1000 * 60 * 60 * 24))
+					: 0;
+				return `- ${f.displayName} (@${f.username}) — friends for ${daysSince} days`;
+			}).join("\n")
+			: "No friends yet";
+
+		const beaconLines = data.beacons.length > 0
+			? data.beacons.map((b) => {
+				const creator = b.creatorId === userUuid
+					? "me"
+					: data.friends.find((f) => f.uuid === b.creatorId)?.displayName ?? "unknown";
+				return `- "${b.title}" by ${creator}${b.description ? ` — ${b.description}` : ""}`;
+			}).join("\n")
+			: "No beacons yet";
+
+		const responseLines = data.beaconResponses.length > 0
+			? data.beaconResponses.map((br) => {
+				const joining = br.responses.filter((r) => r.status === "joining").length;
+				const interested = br.responses.filter((r) => r.status === "interested").length;
+				const declined = br.responses.filter((r) => r.status === "declined").length;
+				return `- "${br.beaconTitle}": ${joining} joining, ${interested} interested, ${declined} can't make it`;
+			}).join("\n")
+			: "No responses yet";
+
+		const noteLines = data.recentNotes.length > 0
+			? data.recentNotes.map((n) => `- ${n.title ? `[${n.title}] ` : ""}${n.text.slice(0, 100)}`).join("\n")
+			: "No notes yet";
+
+		const dateStr = new Date(data.now).toLocaleDateString("en-US", {
+			weekday: "long", month: "long", day: "numeric", year: "numeric",
+		});
+
+		const userMessage = `Here's my social data:
+
+**Me:** ${data.user.displayName} (@${data.user.username})
+
+**Friends (${data.friends.length}):**
+${friendLines}
+
+**Recent Beacons (last 30 days): ${data.beacons.length}**
+${beaconLines}
+
+**Beacon Responses:**
+${responseLines}
+
+**Recent Notes on Canvas:**
+${noteLines}
+
+**Current date:** ${dateStr}
+
+Analyze my social wellness and generate the report.`;
+
+		const res = await fetch("https://api.anthropic.com/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-api-key": apiKey,
+				"anthropic-version": "2023-06-01",
+			},
+			body: JSON.stringify({
+				model: "claude-opus-4-6",
+				max_tokens: 1500,
+				system: systemPrompt,
+				messages: [{ role: "user", content: userMessage }],
+			}),
+		});
+
+		if (!res.ok) {
+			const text = await res.text();
+			console.error("Anthropic API error:", res.status, text);
+			throw new Error("Failed to generate wellness report — try again");
+		}
+
+		const apiData = await res.json();
+		let rawText: string = apiData.content?.[0]?.text ?? "";
+
+		// Strip markdown code fences if Claude wraps them
+		rawText = rawText
+			.replace(/^```(?:json)?\s*/i, "")
+			.replace(/\s*```$/i, "")
+			.trim();
+
+		let report: WellnessReport;
+		try {
+			report = JSON.parse(rawText);
+		} catch {
+			console.error("Failed to parse wellness report:", rawText);
+			throw new Error("AI returned unexpected format — try again");
+		}
+
+		// Validate shape
+		if (
+			!report.overallHealth ||
+			typeof report.healthScore !== "number" ||
+			!report.summary ||
+			!Array.isArray(report.friendInsights) ||
+			!Array.isArray(report.activitySuggestions) ||
+			!report.charityCause ||
+			!report.weeklyNudge
+		) {
+			throw new Error("AI returned unexpected format — try again");
+		}
+
+		return report;
+	},
+});
+
+// ── Demo data seeding (dev-only) ──
+
+export const seedDemoFriends = mutation({
+	args: {},
+	handler: async (ctx) => {
+		// Find the first user (Joe)
+		const joe = await ctx.db.query("users").first();
+		if (!joe) throw new Error("No users exist — sign in first");
+
+		const demoFriends = [
+			{ username: "mango", displayName: "Mango" },
+			{ username: "bishop", displayName: "Bishop" },
+			{ username: "bella", displayName: "Bella" },
+		];
+
+		const createdFriends: string[] = [];
+
+		for (const friend of demoFriends) {
+			// Check if already exists
+			const existing = await ctx.db
+				.query("users")
+				.withIndex("by_username", (q) => q.eq("username", friend.username))
+				.first();
+			if (existing) {
+				createdFriends.push(existing.uuid);
+				continue;
+			}
+
+			const uuid = crypto.randomUUID();
+
+			// Create user
+			await ctx.db.insert("users", {
+				uuid,
+				authAccountId: `demo-${friend.username}`,
+				username: friend.username,
+				displayName: friend.displayName,
+				friendCode: `DEMO${friend.username.toUpperCase().slice(0, 6)}`,
+			});
+
+			// Create personal canvas
+			await ctx.db.insert("canvases", {
+				ownerId: uuid,
+				name: `${friend.displayName}'s canvas`,
+				type: "personal",
+				bounds: { width: 3000, height: 2000 },
+			});
+
+			// Create accepted friendship with Joe (random age within 60 days)
+			await ctx.db.insert("friendships", {
+				requesterId: joe.uuid,
+				receiverId: uuid,
+				status: "accepted",
+				createdAt: Date.now() - Math.floor(Math.random() * 60 * 24 * 60 * 60 * 1000),
+			});
+
+			createdFriends.push(uuid);
+		}
+
+		// Create beacons on Joe's canvas
+		const joeCanvas = await ctx.db
+			.query("canvases")
+			.withIndex("by_owner_type", (q) =>
+				q.eq("ownerId", joe.uuid).eq("type", "personal")
+			)
+			.first();
+
+		if (!joeCanvas) throw new Error("Joe's canvas not found");
+
+		const beaconData = [
+			{
+				title: "Dog Park Meetup",
+				description: "Bringing Rocko for off-leash play — all pups welcome, bring water and poop bags",
+				creatorId: joe.uuid,
+				startTime: Date.now() + 2 * 24 * 60 * 60 * 1000,
+			},
+			{
+				title: "Pack Walk & Coffee",
+				description: "Morning group walk with all the dogs, then hitting the dog-friendly cafe after",
+				creatorId: createdFriends[0],
+				startTime: Date.now() + 1 * 24 * 60 * 60 * 1000,
+			},
+			{
+				title: "Beach Day with the Pups",
+				description: "Sunset beach hangout — dogs run free, humans bring snacks and good vibes",
+				creatorId: createdFriends[2],
+				startTime: Date.now() + 5 * 24 * 60 * 60 * 1000,
+			},
+		];
+
+		for (const beacon of beaconData) {
+			const endTime = beacon.startTime + 3 * 60 * 60 * 1000;
+			const beaconId = await ctx.db.insert("canvasObjects", {
+				canvasId: joeCanvas._id,
+				creatorId: beacon.creatorId,
+				type: "beacon",
+				position: {
+					x: 300 + Math.random() * 1500,
+					y: 200 + Math.random() * 800,
+				},
+				size: { w: 260, h: 100 },
+				content: {
+					title: beacon.title,
+					description: beacon.description,
+					startTime: beacon.startTime,
+					endTime,
+					visibilityType: "canvas" as const,
+				},
+				expiresAt: endTime,
+			});
+
+			// Add varied responses from friends
+			const statuses: Array<"joining" | "interested" | "declined"> = [
+				"joining", "interested", "declined",
+			];
+			for (let i = 0; i < createdFriends.length; i++) {
+				if (createdFriends[i] === beacon.creatorId) continue;
+				await ctx.db.insert("beaconResponses", {
+					beaconId,
+					userId: createdFriends[i],
+					status: statuses[i % 3],
+					respondedAt: Date.now() - Math.floor(Math.random() * 24 * 60 * 60 * 1000),
+				});
+			}
+		}
+
+		return { seeded: createdFriends.length, beacons: beaconData.length };
+	},
+});
+
+/** Seed rich canvas content for demo friends — notes, beacons, music vibes */
+export const seedDemoCanvasData = mutation({
+	args: {},
+	handler: async (ctx) => {
+		const joe = await ctx.db.query("users").first();
+		if (!joe) throw new Error("No users exist — sign in first");
+
+		// Look up demo friends
+		const mango = await ctx.db.query("users").withIndex("by_username", (q) => q.eq("username", "mango")).first();
+		const bishop = await ctx.db.query("users").withIndex("by_username", (q) => q.eq("username", "bishop")).first();
+		const bella = await ctx.db.query("users").withIndex("by_username", (q) => q.eq("username", "bella")).first();
+
+		if (!mango || !bishop || !bella) throw new Error("Run seedDemoFriends first");
+
+		const friends = [mango, bishop, bella];
+		let totalObjects = 0;
+
+		// Content per friend — varied interests and vibes
+		const friendContent: Record<string, {
+			notes: { text: string; title: string; color: number }[];
+			beacons: { title: string; description: string }[];
+		}> = {
+			[mango.uuid]: {
+				notes: [
+					{ text: "Found the BEST dog-friendly patio downtown. Mango got extra treats from the waiter. Living his best life.", title: "Patio Finds", color: 0xfff9c4 },
+					{ text: "Morning trail run with Mango — he kept pace for 5 miles! This golden boy has endless energy.", title: "Trail Adventures", color: 0xc8e6c9 },
+					{ text: "Dog park meetup was a hit. Mango made 3 new friends and stole someone's tennis ball. Classic.", title: "Dog Park Report", color: 0xffe0b2 },
+					{ text: "Teaching Mango agility tricks. He nailed the weave poles but refuses to do the tunnel. We'll get there.", title: "Training Log", color: 0xbbdefb },
+				],
+				beacons: [
+					{ title: "Dog Beach Day", description: "Off-leash beach run at sunrise — bring towels, treats, and your pup's favorite ball" },
+					{ title: "Pack Walk & Coffee", description: "Morning group walk with all the dogs, then hitting the dog-friendly cafe after" },
+				],
+			},
+			[bishop.uuid]: {
+				notes: [
+					{ text: "Bishop learned 'shake' today! This big goofy boy finally gets it. Took about 200 treats but we're here.", title: "Training Wins", color: 0xf8bbd0 },
+					{ text: "Volunteered at the animal shelter Saturday. Bishop was the demo dog for adoptions — 3 dogs found homes!", title: "Shelter Volunteer", color: 0xc8e6c9 },
+					{ text: "Hiking with Bishop at the canyon. He carried his own pack like a champ. 7 miles round trip.", title: "Hiking Buddies", color: 0xffe0b2 },
+					{ text: "Bishop and Rocko had the best playdate. Absolute chaos in the backyard. Wouldn't trade it.", title: "Playdate Recap", color: 0xbbdefb },
+					{ text: "Trying a new raw food diet for Bishop. He's never been this excited about dinner time.", title: "Nutrition Notes", color: 0xfff9c4 },
+				],
+				beacons: [
+					{ title: "Shelter Volunteer Day", description: "Saturday 9am-1pm at the animal shelter. Dogs need walkers and socializers!" },
+					{ title: "Canyon Hike (Dogs Welcome)", description: "Moderate 6-mile loop. Bring water for you AND your pup. Bishop's leading the pack." },
+				],
+			},
+			[bella.uuid]: {
+				notes: [
+					{ text: "Sunset beach walk with Bella was magical. She chased every wave and dug approximately 47 holes.", title: "Beach Life", color: 0xf8bbd0 },
+					{ text: "Bella passed her Canine Good Citizen test! So proud of this sweet girl. Celebratory pupcake tonight.", title: "CGC Certified!", color: 0xbbdefb },
+					{ text: "Planning a dog camping trip for next month. Joshua Tree has pet-friendly sites. Who's in?", title: "Adventure Planning", color: 0xc8e6c9 },
+					{ text: "Farmers market with Bella — she got compliments from every single vendor. Obviously.", title: "Market Walks", color: 0xffe0b2 },
+				],
+				beacons: [
+					{ title: "Sunset Dog Beach Volleyball", description: "Humans play volleyball, dogs run free on the sand. Best of both worlds." },
+					{ title: "Dog-Friendly Brunch", description: "Patio brunch spot that has a puppy menu. Bella recommends the chicken bites." },
+				],
+			},
+		};
+
+		for (const friend of friends) {
+			// Find their personal canvas
+			const canvas = await ctx.db
+				.query("canvases")
+				.withIndex("by_owner_type", (q) => q.eq("ownerId", friend.uuid).eq("type", "personal"))
+				.first();
+			if (!canvas) continue;
+
+			const content = friendContent[friend.uuid];
+			if (!content) continue;
+
+			// Add notes spread across the canvas
+			for (let i = 0; i < content.notes.length; i++) {
+				const note = content.notes[i];
+				await ctx.db.insert("canvasObjects", {
+					canvasId: canvas._id,
+					creatorId: friend.uuid,
+					type: "textblock",
+					position: {
+						x: 150 + (i % 3) * 450 + Math.random() * 100,
+						y: 150 + Math.floor(i / 3) * 400 + Math.random() * 100,
+					},
+					size: { w: 280, h: 120 },
+					content: { text: note.text, color: note.color, title: note.title },
+				});
+				totalObjects++;
+			}
+
+			// Add beacons
+			for (let i = 0; i < content.beacons.length; i++) {
+				const beacon = content.beacons[i];
+				const startTime = Date.now() + (i + 1) * 2 * 24 * 60 * 60 * 1000;
+				const endTime = startTime + 3 * 60 * 60 * 1000;
+				const beaconId = await ctx.db.insert("canvasObjects", {
+					canvasId: canvas._id,
+					creatorId: friend.uuid,
+					type: "beacon",
+					position: {
+						x: 800 + i * 500 + Math.random() * 200,
+						y: 600 + Math.random() * 400,
+					},
+					size: { w: 260, h: 100 },
+					content: {
+						title: beacon.title,
+						description: beacon.description,
+						startTime,
+						endTime,
+						visibilityType: "canvas" as const,
+					},
+					expiresAt: endTime,
+				});
+				totalObjects++;
+
+				// Joe responds to friend beacons
+				await ctx.db.insert("beaconResponses", {
+					beaconId,
+					userId: joe.uuid,
+					status: i === 0 ? "joining" : "interested",
+					respondedAt: Date.now() - Math.floor(Math.random() * 12 * 60 * 60 * 1000),
+				});
+			}
+		}
+
+		return { totalObjects };
+	},
+});

--- a/src/lib/components/CanvasToolbar.svelte
+++ b/src/lib/components/CanvasToolbar.svelte
@@ -16,6 +16,8 @@
 		onCreateBeacon,
 		onAddPhoto,
 		onAddMusic,
+		onWellness,
+		onNavigateToFriend = undefined,
 		friendCode = '',
 		activeCanvasId,
 		canvases,
@@ -34,6 +36,8 @@
 		onCreateBeacon: () => void;
 		onAddPhoto: () => void;
 		onAddMusic: () => void;
+		onWellness: () => void;
+		onNavigateToFriend?: (friendUuid: string, displayName: string) => void;
 		friendCode?: string;
 		activeCanvasId: string | null;
 		canvases: any[] | undefined;
@@ -106,6 +110,8 @@
 	let musicNote: SVGElement = $state(undefined!);
 	let musicWave1: SVGElement = $state(undefined!);
 	let musicWave2: SVGElement = $state(undefined!);
+	let wellnessHeart: SVGElement = $state(undefined!);
+	let wellnessPulse: SVGElement = $state(undefined!);
 
 	// Store tweens for cleanup
 	let idleTweens: gsap.core.Tween[] = [];
@@ -165,6 +171,19 @@
 				})
 			);
 		}
+
+		// Wellness heart idle — gentle breathe
+		if (wellnessPulse) {
+			idleTweens.push(
+				gsap.to(wellnessPulse, {
+					opacity: 0.7,
+					duration: 1.8,
+					ease: 'sine.inOut',
+					yoyo: true,
+					repeat: -1,
+				})
+			);
+		}
 	});
 
 	onDestroy(() => {
@@ -210,6 +229,15 @@
 		tl.to(musicNote, { rotation: 0, duration: 0.12, ease: 'power2.out' });
 		tl.fromTo(musicWave1, { scale: 0.8, opacity: 0.3, transformOrigin: '50% 50%' }, { scale: 1.2, opacity: 0.9, duration: 0.25, ease: 'power2.out' }, 0);
 		tl.fromTo(musicWave2, { scale: 0.8, opacity: 0.2, transformOrigin: '50% 50%' }, { scale: 1.2, opacity: 0.7, duration: 0.25, ease: 'power2.out' }, 0.08);
+	}
+
+	function wellnessEnter() {
+		if (!wellnessHeart || !wellnessPulse) return;
+		const tl = gsap.timeline();
+		tl.to(wellnessHeart, { scale: 1.2, transformOrigin: '50% 50%', duration: 0.15, ease: 'power2.out' });
+		tl.to(wellnessHeart, { scale: 1, duration: 0.2, ease: 'back.out(2)' });
+		tl.to(wellnessPulse, { scale: 1.4, opacity: 1, transformOrigin: '50% 50%', duration: 0.15, ease: 'power2.out' }, 0);
+		tl.to(wellnessPulse, { scale: 1, opacity: 0.4, duration: 0.2, ease: 'power2.out' }, 0.15);
 	}
 
 	function toggleAccountMenu() {
@@ -393,6 +421,26 @@
 		</button>
 	{/if}
 
+	<!-- Wellness button — shows for all authenticated users -->
+	<button
+		onclick={onWellness}
+		onmouseenter={wellnessEnter}
+		class="lego-btn lego-rose flex items-center gap-1.5"
+	>
+		<svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<!-- Heart -->
+			<g bind:this={wellnessHeart}>
+				<path d="M10 17.5l-1.2-1.1C4.5 12.4 2 10.1 2 7.3 2 5 3.8 3.2 6 3.2c1.3 0 2.5.6 3.3 1.5.8-.9 2-1.5 3.3-1.5 2.2 0 4 1.8 4 4.1 0 2.8-2.5 5.1-6.8 9.1L10 17.5z" fill="white" opacity="0.95"/>
+			</g>
+			<!-- Pulse wave -->
+			<path bind:this={wellnessPulse}
+				d="M2 10 L5 10 L7 6 L9 14 L11 8 L13 12 L15 10 L18 10"
+				stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.4"
+			/>
+		</svg>
+		Wellness
+	</button>
+
 	{#if showAccount}
 		<div class="w-px h-5 bg-white/10"></div>
 
@@ -400,7 +448,7 @@
 		<FriendCodeModal {friendCode} />
 
 		<!-- Friends list dropdown -->
-		<FriendsList />
+		<FriendsList {onNavigateToFriend} />
 
 		<!-- Account dropdown -->
 		<div class="relative">

--- a/src/lib/components/FriendsList.svelte
+++ b/src/lib/components/FriendsList.svelte
@@ -4,6 +4,13 @@
 	import gsap from 'gsap';
 	import { onMount, onDestroy } from 'svelte';
 
+	let {
+		onNavigateToFriend = undefined,
+	}: {
+		/** Called when user clicks a friend — navigates to their personal canvas */
+		onNavigateToFriend?: (friendUuid: string, displayName: string) => void;
+	} = $props();
+
 	const client = useConvexClient();
 	const friends = useQuery(api.friendships.getFriends, {});
 	const pendingRequests = useQuery(api.friendships.getPendingRequests, {});
@@ -149,15 +156,28 @@
 					<div class="dropdown-section">
 						<p class="section-label">Connected</p>
 						{#each friends.data as friend (friend.uuid)}
-							<div class="friend-row">
+							<button
+								class="friend-row"
+								onclick={() => {
+									if (onNavigateToFriend) {
+										onNavigateToFriend(friend.uuid, friend.displayName);
+										close();
+									}
+								}}
+							>
 								<div class="friend-avatar">
 									{friend.displayName.charAt(0).toUpperCase()}
 								</div>
-								<div>
+								<div class="friend-row-info">
 									<p class="friend-name">{friend.displayName}</p>
 									<p class="friend-username">@{friend.username}</p>
 								</div>
-							</div>
+								{#if onNavigateToFriend}
+									<svg class="friend-nav-arrow" width="14" height="14" viewBox="0 0 20 20" fill="none">
+										<path d="M7 4l6 6-6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+									</svg>
+								{/if}
+							</button>
 						{/each}
 					</div>
 				{:else if !friends.isLoading}
@@ -315,10 +335,31 @@
 		padding: 6px 4px;
 		border-radius: 8px;
 		transition: background 0.15s;
+		width: 100%;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		text-align: left;
 	}
 
 	.friend-row:hover {
-		background: rgba(255, 255, 255, 0.04);
+		background: rgba(255, 255, 255, 0.06);
+	}
+
+	.friend-row-info {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.friend-nav-arrow {
+		color: rgba(255, 255, 255, 0.25);
+		flex-shrink: 0;
+		transition: color 0.15s, transform 0.15s;
+	}
+
+	.friend-row:hover .friend-nav-arrow {
+		color: rgba(255, 255, 255, 0.5);
+		transform: translateX(2px);
 	}
 
 	.friend-avatar {

--- a/src/lib/components/WellnessPanel.svelte
+++ b/src/lib/components/WellnessPanel.svelte
@@ -1,0 +1,337 @@
+<script lang="ts">
+	import { useConvexClient } from 'convex-svelte';
+	import { api } from '$convex/_generated/api';
+	import gsap from 'gsap';
+	import { onMount, onDestroy } from 'svelte';
+	import type { WellnessReport } from '../../convex/wellness';
+
+	let {
+		onClose,
+	}: {
+		onClose: () => void;
+	} = $props();
+
+	const client = useConvexClient();
+
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let report = $state<WellnessReport | null>(null);
+
+	// Element refs
+	let backdrop: HTMLDivElement;
+	let panel: HTMLDivElement;
+	let contentSection: HTMLDivElement;
+
+	// Animation storage
+	let entranceTl: gsap.core.Timeline | null = null;
+
+	// Health status display config
+	const healthConfig: Record<string, { emoji: string; color: string; label: string; ring: string }> = {
+		'thriving': { emoji: '\u{1F31F}', color: '#34d399', label: 'Thriving', ring: 'rgba(52, 211, 153, 0.15)' },
+		'connected': { emoji: '\u{1F91D}', color: '#60a5fa', label: 'Connected', ring: 'rgba(96, 165, 250, 0.15)' },
+		'growing': { emoji: '\u{1F331}', color: '#fbbf24', label: 'Growing', ring: 'rgba(251, 191, 36, 0.15)' },
+		'needs-attention': { emoji: '\u{1F4AD}', color: '#f87171', label: 'Needs Love', ring: 'rgba(248, 113, 113, 0.15)' },
+	};
+
+	const friendStatusConfig: Record<string, { color: string; bg: string }> = {
+		'thriving': { color: '#34d399', bg: 'rgba(52, 211, 153, 0.12)' },
+		'connected': { color: '#60a5fa', bg: 'rgba(96, 165, 250, 0.12)' },
+		'drifting': { color: '#fbbf24', bg: 'rgba(251, 191, 36, 0.12)' },
+		'new': { color: '#c084fc', bg: 'rgba(192, 132, 252, 0.12)' },
+	};
+
+	async function fetchReport() {
+		loading = true;
+		error = null;
+		try {
+			report = await client.action(api.wellness.generateReport, {}) as WellnessReport;
+		} catch (err: any) {
+			console.error('Wellness report failed:', err);
+			error = err.message || 'Failed to generate report';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleClose() {
+		const closeTl = gsap.timeline({ onComplete: () => onClose() });
+		closeTl.to(panel, { scale: 0.95, opacity: 0, duration: 0.25, ease: 'power2.in' }, 0);
+		closeTl.to(backdrop, { opacity: 0, duration: 0.2 }, 0.1);
+	}
+
+	onMount(() => {
+		gsap.fromTo(backdrop, { opacity: 0 }, { opacity: 1, duration: 0.3 });
+
+		entranceTl = gsap.timeline();
+		entranceTl.fromTo(panel,
+			{ scale: 0.92, opacity: 0, y: 20 },
+			{ scale: 1, opacity: 1, y: 0, duration: 0.5, ease: 'back.out(1.4)' },
+			0
+		);
+
+		fetchReport();
+	});
+
+	onDestroy(() => {
+		if (entranceTl) { entranceTl.kill(); entranceTl = null; }
+	});
+
+	// Stagger-animate sections when report arrives
+	$effect(() => {
+		if (report && contentSection) {
+			const sections = Array.from(contentSection.children);
+			gsap.fromTo(sections,
+				{ y: 12, opacity: 0 },
+				{ y: 0, opacity: 1, duration: 0.35, ease: 'power2.out', stagger: 0.08 }
+			);
+		}
+	});
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div
+	bind:this={backdrop}
+	class="fixed inset-0 z-50 flex items-end sm:items-center justify-center glass-backdrop"
+	onclick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+>
+	<div
+		bind:this={panel}
+		class="glass-panel rounded-t-2xl sm:rounded-2xl w-full max-w-2xl mx-0 sm:mx-4 overflow-hidden max-h-[90vh] flex flex-col relative"
+		style="will-change: transform;"
+	>
+		<!-- Ambient pink glow -->
+		<div class="wellness-orb"></div>
+
+		<!-- Header -->
+		<div class="p-6 pb-3 flex-shrink-0 relative z-10">
+			<div class="flex items-start justify-between mb-2">
+				<div class="flex items-center gap-3">
+					<div class="wellness-icon-ring">
+						<svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+							<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" fill="#f472b6"/>
+						</svg>
+					</div>
+					<h2 class="text-lg font-bold text-white" style="font-family: 'Geist Mono', monospace;">Social Wellness</h2>
+				</div>
+				<button
+					onclick={handleClose}
+					class="text-white/40 hover:text-white/70 transition cursor-pointer flex-shrink-0 mt-1"
+				>
+					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+					</svg>
+				</button>
+			</div>
+			<p class="text-xs text-white/40" style="font-family: 'Geist Mono', monospace;">
+				Powered by Claude Opus 4.6
+			</p>
+		</div>
+
+		<!-- Content -->
+		<div bind:this={contentSection} class="flex-1 overflow-y-auto px-6 pb-6 relative z-10 space-y-4">
+
+			{#if loading}
+				<div class="flex flex-col items-center py-12 gap-4">
+					<div class="wellness-pulse-loader">
+						<svg width="48" height="48" viewBox="0 0 24 24" fill="none">
+							<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" fill="#f472b6" opacity="0.6"/>
+						</svg>
+					</div>
+					<p class="text-sm text-white/50" style="font-family: 'Geist Mono', monospace;">
+						Analyzing your social graph...
+					</p>
+					<p class="text-xs text-white/30" style="font-family: 'Geist Mono', monospace;">
+						Claude is reading your friendships, beacons, and activity
+					</p>
+				</div>
+
+			{:else if error}
+				<div class="flex flex-col items-center py-12 gap-4">
+					<p class="text-sm text-red-400/80" style="font-family: 'Geist Mono', monospace;">
+						{error}
+					</p>
+					<button onclick={fetchReport} class="lego-btn lego-rose text-sm">
+						Try again
+					</button>
+				</div>
+
+			{:else if report}
+				<!-- Health Badge -->
+				<div class="flex items-center gap-4 p-4 rounded-xl" style="background: {healthConfig[report.overallHealth]?.ring ?? 'rgba(96,165,250,0.15)'};">
+					<div class="health-score-ring" style="--ring-color: {healthConfig[report.overallHealth]?.color ?? '#60a5fa'};">
+						<span class="text-2xl">{healthConfig[report.overallHealth]?.emoji ?? '\u{2728}'}</span>
+						<span class="health-score-number" style="color: {healthConfig[report.overallHealth]?.color ?? '#60a5fa'};">{report.healthScore}</span>
+					</div>
+					<div class="flex-1">
+						<p class="text-sm font-semibold" style="color: {healthConfig[report.overallHealth]?.color ?? '#60a5fa'}; font-family: 'Geist Mono', monospace;">
+							{healthConfig[report.overallHealth]?.label ?? 'Unknown'}
+						</p>
+						<p class="text-sm text-white/70 mt-1" style="font-family: 'Geist Mono', monospace;">
+							{report.summary}
+						</p>
+					</div>
+				</div>
+
+				<!-- Friend Insights -->
+				{#if report.friendInsights.length > 0}
+					<div>
+						<h3 class="text-xs font-medium text-white/50 uppercase tracking-wider mb-2" style="font-family: 'Geist Mono', monospace;">
+							Friend Insights
+						</h3>
+						<div class="space-y-2">
+							{#each report.friendInsights as friend}
+								{@const cfg = friendStatusConfig[friend.status] ?? { color: '#60a5fa', bg: 'rgba(96,165,250,0.12)' }}
+								<div class="friend-insight-card" style="border-left: 3px solid {cfg.color};">
+									<div class="flex items-center gap-2 mb-1">
+										<span class="text-base">{friend.emoji}</span>
+										<span class="text-sm font-semibold text-white/90" style="font-family: 'Geist Mono', monospace;">{friend.name}</span>
+										<span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded" style="background: {cfg.bg}; color: {cfg.color}; font-family: 'Geist Mono', monospace;">
+											{friend.status}
+										</span>
+									</div>
+									<p class="text-xs text-white/60 mb-1" style="font-family: 'Geist Mono', monospace;">{friend.insight}</p>
+									<p class="text-xs text-white/40 italic" style="font-family: 'Geist Mono', monospace;">{friend.suggestion}</p>
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
+
+				<!-- Activity Suggestions -->
+				{#if report.activitySuggestions.length > 0}
+					<div>
+						<h3 class="text-xs font-medium text-white/50 uppercase tracking-wider mb-2" style="font-family: 'Geist Mono', monospace;">
+							Hangout Ideas
+						</h3>
+						<div class="space-y-2">
+							{#each report.activitySuggestions as activity}
+								<div class="activity-card">
+									<div class="flex items-center gap-2 mb-1">
+										<span class="text-lg">{activity.emoji}</span>
+										<span class="text-sm font-semibold text-white/90" style="font-family: 'Geist Mono', monospace;">{activity.title}</span>
+									</div>
+									<p class="text-xs text-white/60 mb-1.5" style="font-family: 'Geist Mono', monospace;">{activity.description}</p>
+									<div class="flex gap-3 text-[10px] text-white/40" style="font-family: 'Geist Mono', monospace;">
+										<span>{activity.bestFor}</span>
+										<span>{activity.timing}</span>
+									</div>
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
+
+				<!-- Impact Connector -->
+				<div>
+					<h3 class="text-xs font-medium text-white/50 uppercase tracking-wider mb-2" style="font-family: 'Geist Mono', monospace;">
+						Impact Connector
+					</h3>
+					<div class="charity-card">
+						<div class="flex items-center gap-2 mb-2">
+							<span class="text-lg">{report.charityCause.emoji}</span>
+							<span class="text-sm font-semibold text-emerald-300" style="font-family: 'Geist Mono', monospace;">{report.charityCause.cause}</span>
+						</div>
+						<p class="text-xs text-white/60 mb-2" style="font-family: 'Geist Mono', monospace;">{report.charityCause.whyItFits}</p>
+						<div class="flex items-start gap-2 px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
+							<p class="text-xs text-emerald-300/80" style="font-family: 'Geist Mono', monospace;">{report.charityCause.firstStep}</p>
+						</div>
+					</div>
+				</div>
+
+				<!-- Weekly Nudge -->
+				<div class="weekly-nudge">
+					<div class="flex items-center gap-2 mb-2">
+						<h3 class="text-xs font-medium text-amber-400/80 uppercase tracking-wider" style="font-family: 'Geist Mono', monospace;">
+							This Week's Nudge
+						</h3>
+					</div>
+					<p class="text-sm text-white/80" style="font-family: 'Geist Mono', monospace;">
+						{report.weeklyNudge}
+					</p>
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.wellness-orb {
+		position: absolute;
+		top: 30%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: 400px;
+		height: 400px;
+		border-radius: 50%;
+		background: radial-gradient(circle, rgba(244, 114, 182, 0.10) 0%, rgba(244, 114, 182, 0.04) 30%, transparent 60%);
+		pointer-events: none;
+	}
+
+	.wellness-icon-ring {
+		width: 40px;
+		height: 40px;
+		border-radius: 50%;
+		background: rgba(244, 114, 182, 0.15);
+		border: 1px solid rgba(244, 114, 182, 0.3);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+
+	.wellness-pulse-loader {
+		animation: wellnessPulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes wellnessPulse {
+		0%, 100% { transform: scale(1); opacity: 0.6; }
+		50% { transform: scale(1.15); opacity: 1; }
+	}
+
+	.health-score-ring {
+		width: 72px;
+		height: 72px;
+		border-radius: 50%;
+		border: 3px solid var(--ring-color);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		background: rgba(0, 0, 0, 0.2);
+		gap: 2px;
+	}
+
+	.health-score-number {
+		font-size: 0.7rem;
+		font-weight: 700;
+		font-family: 'Geist Mono', monospace;
+	}
+
+	.friend-insight-card {
+		padding: 0.75rem;
+		border-radius: 0.5rem;
+		background: rgba(255, 255, 255, 0.03);
+	}
+
+	.activity-card {
+		padding: 0.75rem;
+		border-radius: 0.5rem;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(255, 255, 255, 0.05);
+	}
+
+	.charity-card {
+		padding: 0.75rem;
+		border-radius: 0.5rem;
+		background: rgba(16, 185, 129, 0.05);
+		border: 1px solid rgba(16, 185, 129, 0.15);
+	}
+
+	.weekly-nudge {
+		padding: 0.75rem 1rem;
+		border-radius: 0.75rem;
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.08) 0%, rgba(245, 158, 11, 0.04) 100%);
+		border: 1px solid rgba(251, 191, 36, 0.15);
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 	import AddMusicModal from '$lib/components/AddMusicModal.svelte';
 	import CanvasStylePicker from '$lib/components/CanvasStylePicker.svelte';
 	import ViewerAvatars from '$lib/components/ViewerAvatars.svelte';
+	import WellnessPanel from '$lib/components/WellnessPanel.svelte';
 	import { TextBlock } from '$lib/canvas/objects/TextBlock';
 
 	let canvasContainer: HTMLDivElement;
@@ -56,6 +57,7 @@
 	let stickerPickerState = $state<{ objectId: string; x: number; y: number } | null>(null);
 	let selectedPhoto = $state<any>(null);
 	let showAddMusic = $state(false);
+	let showWellness = $state(false);
 	let playingMusicId = $state<string | null>(null);
 	let overlayMode = $state<'none' | 'dots' | 'lines'>('none');
 	let dragOver = $state(false);
@@ -529,6 +531,7 @@
 	function handleEscape(e: KeyboardEvent) {
 		if (e.key !== 'Escape') return;
 		// Close the topmost open modal (order: overlays first, then panels, then pickers)
+		if (showWellness) { showWellness = false; return; }
 		if (inlineEditState) { closeInlineEditor(); return; }
 		if (showAddMusic) { showAddMusic = false; return; }
 		if (showCreateBeacon) { showCreateBeacon = false; return; }
@@ -998,6 +1001,13 @@
 		onCreateBeacon={() => { showCreateBeacon = true; }}
 		onAddPhoto={addPhoto}
 		onAddMusic={() => { showAddMusic = true; }}
+		onWellness={() => { showWellness = true; }}
+		onNavigateToFriend={(friendUuid, displayName) => {
+			const canvas = accessibleCanvases.data?.find((c: any) => c.ownerId === friendUuid && c.type === 'personal');
+			if (canvas) {
+				switchCanvas(canvas._id, `${displayName}'s Canvas`);
+			}
+		}}
 		friendCode={currentUser.user?.friendCode ?? ''}
 		activeCanvasId={activeCanvasId}
 		canvases={accessibleCanvases.data}
@@ -1018,6 +1028,7 @@
 		onCreateBeacon={() => {}}
 		onAddPhoto={() => {}}
 		onAddMusic={() => {}}
+		onWellness={() => {}}
 		activeCanvasId={null}
 		canvases={undefined}
 		onSelectCanvas={() => {}}
@@ -1123,6 +1134,12 @@
 		canvasId={activeCanvasId}
 		onClose={() => { showAddMusic = false; }}
 		onCreated={() => { showAddMusic = false; }}
+	/>
+{/if}
+
+{#if showWellness}
+	<WellnessPanel
+		onClose={() => { showWellness = false; }}
 	/>
 {/if}
 


### PR DESCRIPTION
## Summary
- **Backend**: Claude Opus 4.6-powered social wellness report — analyzes friendships, beacons, activity patterns and generates health scores, friend insights, activity suggestions, and charity cause connections
- **Frontend**: Glassmorphic WellnessPanel with GSAP animations, loading state, and all report sections
- **Toolbar**: Heart/pulse wellness button (lego-rose) visible to all authenticated users
- **Friend navigation**: Clicking a friend in "Your People" dropdown navigates to their canvas
- **Demo seeding**: 3 dog friends (Mango, Bishop, Bella) with rich canvas content

## Test plan
- [ ] Log in → click Wellness button → verify loading state → report renders with all sections
- [ ] Verify friend navigation: Your People → click friend name → switches to their canvas
- [ ] Run `npx convex run wellness:seedDemoFriends` + `seedDemoCanvasData` on production
- [ ] Test Escape key closes panel
- [ ] Verify build passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)